### PR TITLE
Use native os.hostname rather than exec

### DIFF
--- a/netutil.js
+++ b/netutil.js
@@ -50,7 +50,7 @@ exports.isPortOpen = function(hostname, port, timeout, callback) {
 };
 
 exports.getHostName = function(callback) {
-    callback(os.hostname());
+    callback(null,os.hostname());
 };
 
 function asyncRepeat(callback, onDone) {


### PR DESCRIPTION
If getHostName is called repeatedly it will throw an EMFILE error, plus it takes on average 4ms per call. The native call takes on average .001ms per call.
